### PR TITLE
Fix compiling issue. Use ed25519-compact 2.0.6 version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "1", features = ["derive"] }
 rand_core = "^0.6"
 getrandom = "0"
 sha2 = { version = "0.10", default-features = false, features = ["std", "oid"] }
-ed25519-compact = { version = "2", features = ["std", "traits"] }
+ed25519-compact = { version = "=2.0.6", features = ["std", "traits"] }
 p256 = { version = "0.10", default-features = false, features = [
     "arithmetic",
     "ecdsa",


### PR DESCRIPTION
Fix compiling issue
```
❯ cargo build
   Compiling helium-crypto v0.8.3 (/home/kurotych/Sources/helium-crypto-rs)
error[E0277]: the trait bound `ed25519_compact::Signature: signature::Signature` is not satisfied
   --> src/ed25519/mod.rs:103:22
    |
103 |         Ok(Signature(signature::Signature::from_bytes(input)?))
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `signature::Signature` is not implemented for `ed25519_compact::Signature`
    |
    = help: the following other types implement trait `signature::Signature`:
              ecdsa::der::Signature<C>
              ecdsa::Signature<C>
              ecc_compact::Signature
              ed25519::Signature
              secp256k1::Signature
              k256::ecdsa::recoverable::Signature

error[E0599]: no method named `as_bytes` found for struct `ed25519_compact::Signature` in the current scope
   --> src/ed25519/mod.rs:107:16
    |
107 |         self.0.as_bytes()
    |                ^^^^^^^^ method not found in `Signature`

error[E0277]: the trait bound `ed25519_compact::Signature: signature::Signature` is not satisfied
   --> src/ed25519/mod.rs:141:22
    |
141 |         Ok(Signature(signature::Signature::from_bytes(bytes)?))
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `signature::Signature` is not implemented for `ed25519_compact::Signature`
    |
    = help: the following other types implement trait `signature::Signature`:
              ecdsa::der::Signature<C>
              ecdsa::Signature<C>
              ecc_compact::Signature
              ed25519::Signature
              secp256k1::Signature
              k256::ecdsa::recoverable::Signature

error[E0277]: the trait bound `ed25519_compact::Signature: signature::Signature` is not satisfied
   --> src/ed25519/mod.rs:153:9
    |
153 |         signature::Signature::from_bytes(input)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `signature::Signature` is not implemented for `ed25519_compact::Signature`
    |
    = help: the following other types implement trait `signature::Signature`:
              ecdsa::der::Signature<C>
              ecdsa::Signature<C>
              ecc_compact::Signature
              ed25519::Signature
              secp256k1::Signature
              k256::ecdsa::recoverable::Signature
 ```